### PR TITLE
fix typo in ParseBytes()

### DIFF
--- a/config.go
+++ b/config.go
@@ -373,8 +373,8 @@ func Parse(path string) error {
 // ParseBytes takes a TOML file in byte array format and loads it into the
 // global ConfigSet. This must be called after all config flags have been defined
 // but before the flags are accessed by the program.
-func ParseBytes(path string) error {
-	return globalConfig.Parse(path)
+func ParseBytes(data []byte) error {
+	return globalConfig.ParseBytes(data)
 }
 
 // -- Custom Types


### PR DESCRIPTION
I'm pretty sure that this is a copy and paste error and that your intended behavior of ParseBytes() is to take a byte array just like ConfigSet.ParseBytes() 